### PR TITLE
Truncate long RPM names rather than throwing an exception

### DIFF
--- a/rpm/src/main/java/org/eclipse/packager/rpm/build/RpmWriter.java
+++ b/rpm/src/main/java/org/eclipse/packager/rpm/build/RpmWriter.java
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.text.Normalizer;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Supplier;
@@ -137,19 +138,11 @@ public class RpmWriter implements AutoCloseable
         // write package name
 
         {
-            final ByteBuffer nameData = StandardCharsets.UTF_8.encode ( this.lead.getName () );
-            final int len = nameData.remaining ();
-            if ( len > 66 )
-            {
-                throw new IOException ( "Name exceeds 66 bytes" );
-            }
-
-            lead.put ( nameData );
-            if ( len < 66 )
-            {
-                // fill up
-                lead.put ( Rpms.EMPTY_128, 0, 66 - len );
-            }
+            final String name = this.lead.getName ();
+            final byte[] nameEncoded = ( !Normalizer.isNormalized( name, Normalizer.Form.NFC ) ? Normalizer.normalize( name, Normalizer.Form.NFC ) : name ).getBytes( StandardCharsets.UTF_8 );
+            final byte[] nameData = new byte[66];
+            System.arraycopy( nameEncoded, 0, nameData, 0, nameEncoded.length < nameData.length ? nameEncoded.length : nameData.length - 1 );
+            lead.put( nameData );
         }
 
         // 2 bytes OS

--- a/rpm/src/test/java/org/eclipse/packager/rpm/Issue136Test.java
+++ b/rpm/src/test/java/org/eclipse/packager/rpm/Issue136Test.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2015, 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.packager.rpm;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.eclipse.packager.rpm.app.Dumper;
+import org.eclipse.packager.rpm.build.RpmBuilder;
+import org.eclipse.packager.rpm.info.RpmInformations;
+import org.eclipse.packager.rpm.parse.InputHeader;
+import org.eclipse.packager.rpm.parse.RpmInputStream;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class Issue136Test
+{
+    private static final Path OUT_BASE = Paths.get ( "target", "data", "out" );
+
+    private static final String LONG_NAME = "ixufahyknfcniszxvctoioywushlidcjtolzknxiqffxbagcukfxczfmvdrktzchcjbhuzqhgtwmhqwqpdfgbkihwjucybiavxer";
+
+    @BeforeClass
+    public static void setup () throws IOException
+    {
+        Files.createDirectories ( OUT_BASE );
+    }
+
+    @Test
+    public void test () throws IOException
+    {
+        Path outFile;
+
+        try ( RpmBuilder builder = new RpmBuilder ( LONG_NAME, "1.0.0", "1", "noarch", OUT_BASE ) )
+        {
+            outFile = builder.getTargetFile ();
+
+            builder.build ();
+        }
+
+        try ( final RpmInputStream in = new RpmInputStream ( new BufferedInputStream ( Files.newInputStream ( outFile ) ) ) )
+        {
+            Dumper.dumpAll ( in );
+
+            final RpmLead lead = in.getLead();
+            final InputHeader<RpmTag> header = in.getPayloadHeader ();
+            final String name = RpmInformations.asString ( header.getTag ( RpmTag.NAME ) );
+
+            Assert.assertEquals ( LONG_NAME.length(), name.length() );
+            Assert.assertEquals ( 65, lead.getName().length() );
+        }
+    }
+
+}


### PR DESCRIPTION
Signed-off-by: David Walluck <dwalluck@redhat.com>