### PR TITLE
Make SHA256 the default HashAlgorithm.

### DIFF
--- a/rpm/src/main/java/org/eclipse/packager/rpm/HashAlgorithm.java
+++ b/rpm/src/main/java/org/eclipse/packager/rpm/HashAlgorithm.java
@@ -42,7 +42,7 @@ public enum HashAlgorithm {
      * <p>
      * This method will return the hash algorithm as specified by the
      * parameter "name". If this parameter is {@code null} or an empty
-     * string, then the default algorithm {@link #SHA1} will be returned. If
+     * string, then the default algorithm {@link #SHA256} will be returned. If
      * algorithm is an invalid name, then an exception is thrown.
      * </p>
      *
@@ -52,7 +52,7 @@ public enum HashAlgorithm {
      */
     public static HashAlgorithm from(final String name) {
         if (name == null || name.isEmpty()) {
-            return SHA1;
+            return SHA256;
         }
 
         return HashAlgorithm.valueOf(name);

--- a/rpm/src/main/java/org/eclipse/packager/rpm/signature/RsaHeaderSignatureProcessor.java
+++ b/rpm/src/main/java/org/eclipse/packager/rpm/signature/RsaHeaderSignatureProcessor.java
@@ -50,7 +50,7 @@ public class RsaHeaderSignatureProcessor implements SignatureProcessor {
     }
 
     public RsaHeaderSignatureProcessor(final PGPPrivateKey privateKey) {
-        this(privateKey, HashAlgorithmTags.SHA1);
+        this(privateKey, HashAlgorithmTags.SHA256);
     }
 
     @Override

--- a/rpm/src/main/java/org/eclipse/packager/rpm/signature/RsaSignatureProcessor.java
+++ b/rpm/src/main/java/org/eclipse/packager/rpm/signature/RsaSignatureProcessor.java
@@ -53,7 +53,7 @@ public class RsaSignatureProcessor implements SignatureProcessor {
     }
 
     public RsaSignatureProcessor(final PGPPrivateKey privateKey) {
-        this(privateKey, HashAlgorithmTags.SHA1);
+        this(privateKey, HashAlgorithmTags.SHA256);
     }
 
     @Override

--- a/rpm/src/main/java/org/eclipse/packager/rpm/yum/RepositoryCreator.java
+++ b/rpm/src/main/java/org/eclipse/packager/rpm/yum/RepositoryCreator.java
@@ -440,7 +440,7 @@ public class RepositoryCreator {
         }
 
         public Builder setSigning(final PGPPrivateKey privateKey) {
-            return setSigning(privateKey, HashAlgorithmTags.SHA1);
+            return setSigning(privateKey, HashAlgorithmTags.SHA256);
         }
 
         public Builder setSigning(final PGPPrivateKey privateKey, final HashAlgorithm hashAlgorithm) {


### PR DESCRIPTION
As of 2020, attacks against SHA1 need to be considered practical. It is therefore recommended to move on to a more secure hash algorithm.

Other OpenPGP implementations, such as Sequoia-PGP moved on as well. See e.g. https://sequoia-pgp.org/blog/2023/02/01/202302-happy-sha1-day/

Forked out of #48 