### PR TITLE
Use Testcontainers for tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,12 +75,13 @@
         <java.source>11</java.source>
 
         <bouncycastle.version>1.77</bouncycastle.version>
-        <commons-compress.version>1.26.0</commons-compress.version>
+        <commons-compress.version>1.26.1</commons-compress.version>
         <commons-codec.version>1.16.1</commons-codec.version>
         <guava.version>33.0.0-jre</guava.version>
         <junit.jupiter.version>5.8.2</junit.jupiter.version>
         <logback.version>1.5.0</logback.version>
         <slf4j.version>2.0.12</slf4j.version>
+        <testcontainers.version>1.19.7</testcontainers.version>
         <xz.version>1.9</xz.version>
 
         <mavenVersion>3.2.5</mavenVersion>
@@ -200,6 +201,22 @@
                 <version>${junit.jupiter.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>${testcontainers.version}</version>
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-codec</groupId>
+                        <artifactId>commons-codec</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-compress</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
         </dependencies>

--- a/rpm/pom.xml
+++ b/rpm/pom.xml
@@ -25,6 +25,10 @@
             <artifactId>commons-compress</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
@@ -51,6 +55,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- show log output during tests using logback as the slf4j backend. -->

--- a/rpm/src/test/java/org/eclipse/packager/rpm/signature/RpmFileSignatureProcessorTest.java
+++ b/rpm/src/test/java/org/eclipse/packager/rpm/signature/RpmFileSignatureProcessorTest.java
@@ -18,15 +18,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.testcontainers.containers.Container.ExecResult;
+import static org.testcontainers.images.builder.Transferable.DEFAULT_FILE_MODE;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.bouncycastle.openpgp.PGPException;
 import org.eclipse.packager.rpm.HashAlgorithm;
@@ -34,152 +35,100 @@ import org.eclipse.packager.rpm.RpmSignatureTag;
 import org.eclipse.packager.rpm.Rpms;
 import org.eclipse.packager.rpm.parse.InputHeader;
 import org.eclipse.packager.rpm.parse.RpmInputStream;
-import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
-import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 
-import com.google.common.io.ByteStreams;
+import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.images.builder.Transferable;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
-@TestMethodOrder(OrderAnnotation.class)
+@Testcontainers
 public class RpmFileSignatureProcessorTest {
+    private static final Path RPM = Path.of("src/test/resources/data/org.eclipse.scada-0.2.1-1.noarch.rpm");
 
-    private static final String SOURCE_FILE_PATH = "src/test/resources/data/org.eclipse.scada-0.2.1-1.noarch.rpm";
+    private static final Path PRIVATE_KEY = Path.of("src/test/resources/key/private_key.txt");
 
-    private static final String PRIVATE_KEY_PATH = "src/test/resources/key/private_key.txt";
+    private static final Path PUBLIC_KEY = Path.of("src/test/resources/key/public_key.txt");
 
-    private static final String PUBLIC_KEY_PATH = "src/test/resources/key/public_key.txt";
+    private static final String COMMAND = "sleep infinity";
 
-    private static final String RESULT_DIR = "target/test-data/signature";
+    private static Path signedRpm;
 
-    private static final String RESULT_FILE_PATH = RESULT_DIR + "/org.eclipse.scada-0.2.1-1.noarch.rpm";
+    @TempDir
+    static Path resultDirectory;
 
-    private static final String CONTAINER = System.getenv().getOrDefault("CONTAINER_RUNTIME", "podman");
-
-    private static final Optional<String> MOUNT_SUFFIX = Optional.ofNullable(System.getenv().get("CONTAINER_MOUNT_SUFFIX"));
-
-    @Test
-    @Order(1)
-    public void testSigningExistingRpm() throws IOException, PGPException {
+    @BeforeAll
+    static void testSigningExistingRpm() throws IOException, PGPException {
         // Read files
         final String passPhrase = "testkey"; // Do not change
-        Path rpm = Path.of(SOURCE_FILE_PATH);
-        Path private_key = Path.of(PRIVATE_KEY_PATH);
-        if (!Files.exists(rpm) || !Files.exists(private_key)) {
+
+        if (!Files.exists(RPM) || !Files.exists(PRIVATE_KEY)) {
             fail("Input files rpm or private_key does not exist");
         }
+
         // Init the signed RPM
-        Path resultDirectory = Path.of(RESULT_DIR);
-        Files.createDirectories(resultDirectory);
-        Path signedRpm = Path.of(RESULT_FILE_PATH);
+        signedRpm = resultDirectory.resolve("org.eclipse.scada-0.2.1-1.noarch.rpm");
 
-        try (OutputStream resultOut = Files.newOutputStream(signedRpm, CREATE_NEW);
-            InputStream privateKeyStream = Files.newInputStream(private_key)) {
+        try (final OutputStream resultOut = Files.newOutputStream(signedRpm, CREATE_NEW);
+             final InputStream privateKeyStream = Files.newInputStream(PRIVATE_KEY)) {
             // Sign the RPM
-            RpmFileSignatureProcessor.perform(rpm, privateKeyStream, passPhrase, resultOut, HashAlgorithm.SHA256);
-
-            // Read the initial (unsigned) rpm file
-            RpmInputStream initialRpm = new RpmInputStream(Files.newInputStream(rpm));
-            initialRpm.available();
-            initialRpm.close();
-            InputHeader<RpmSignatureTag> initialHeader = initialRpm.getSignatureHeader();
+            RpmFileSignatureProcessor.perform(RPM, privateKeyStream, passPhrase, resultOut, HashAlgorithm.SHA256);
 
             // Read the signed rpm file
-            RpmInputStream rpmSigned = new RpmInputStream(Files.newInputStream(signedRpm));
-            rpmSigned.available();
-            rpmSigned.close();
-            InputHeader<RpmSignatureTag> signedHeader = rpmSigned.getSignatureHeader();
+            try (RpmInputStream initialRpm = new RpmInputStream(Files.newInputStream(RPM)); RpmInputStream rpmSigned = new RpmInputStream(Files.newInputStream(signedRpm))) {
+                InputHeader<RpmSignatureTag> initialHeader = initialRpm.getSignatureHeader();
+                InputHeader<RpmSignatureTag> signedHeader = rpmSigned.getSignatureHeader();
+                // Get information of the signed rpm file
+                int signedSize = (int) signedHeader.getEntry(RpmSignatureTag.SIZE).get().getValue();
+                int signedPayloadSize = (int) signedHeader.getEntry(RpmSignatureTag.PAYLOAD_SIZE).get().getValue();
+                String signedSha1 = signedHeader.getEntry(RpmSignatureTag.SHA1HEADER).get().getValue().toString();
+                String signedMd5 = Rpms.dumpValue(signedHeader.getEntry(RpmSignatureTag.MD5).get().getValue());
+                String pgpSignature = Rpms.dumpValue(signedHeader.getEntry(RpmSignatureTag.PGP).get().getValue());
+                // Get information of the initial rpm file
+                int initialSize = (int) initialHeader.getEntry(RpmSignatureTag.SIZE).get().getValue();
+                int initialPayloadSize = (int) initialHeader.getEntry(RpmSignatureTag.PAYLOAD_SIZE).get().getValue();
+                String initialSha1 = initialHeader.getEntry(RpmSignatureTag.SHA1HEADER).get().getValue().toString();
+                String initialMd5 = Rpms.dumpValue(initialHeader.getEntry(RpmSignatureTag.MD5).get().getValue());
 
-            // Get information of the initial rpm file
-            int initialSize = (int) initialHeader.getEntry(RpmSignatureTag.SIZE).get().getValue();
-            int initialPayloadSize = (int) initialHeader.getEntry(RpmSignatureTag.PAYLOAD_SIZE).get().getValue();
-            String initialSha1 = initialHeader.getEntry(RpmSignatureTag.SHA1HEADER).get().getValue().toString();
-            String initialMd5 = Rpms.dumpValue(initialHeader.getEntry(RpmSignatureTag.MD5).get().getValue());
+                // Compare information values of initial rpm and signed rpm
+                assertEquals(initialSize, signedSize);
+                assertEquals(initialPayloadSize, signedPayloadSize);
+                assertEquals(initialSha1, signedSha1);
+                assertEquals(initialMd5, signedMd5);
 
-            // Get information of the signed rpm file
-            int signedSize = (int) signedHeader.getEntry(RpmSignatureTag.SIZE).get().getValue();
-            int signedPayloadSize = (int) signedHeader.getEntry(RpmSignatureTag.PAYLOAD_SIZE).get().getValue();
-            String signedSha1 = signedHeader.getEntry(RpmSignatureTag.SHA1HEADER).get().getValue().toString();
-            String signedMd5 = Rpms.dumpValue(signedHeader.getEntry(RpmSignatureTag.MD5).get().getValue());
-            String pgpSignature = Rpms.dumpValue(signedHeader.getEntry(RpmSignatureTag.PGP).get().getValue());
-
-            // Compare information values of initial rpm and signed rpm
-            assertEquals(initialSize, signedSize);
-            assertEquals(initialPayloadSize, signedPayloadSize);
-            assertEquals(initialSha1, signedSha1);
-            assertEquals(initialMd5, signedMd5);
-
-            // Verify if signature is present
-            assertNotNull(pgpSignature);
+                // Verify if signature is present
+                assertNotNull(pgpSignature);
+            }
         }
     }
 
     @Test
-    @Order(2)
-    public void verifyRpmSignature() throws Exception {
-        // get the files, as absolute paths, as podman will need absolute paths
-        Path publicKey = Path.of(PUBLIC_KEY_PATH).toAbsolutePath();
-        Path signedRpm = Path.of(RESULT_FILE_PATH).toAbsolutePath();
-
+    void verifyRpmSignature() throws Exception {
         // check if the output from the previous test is found
-        if (!Files.exists(publicKey) || !Files.exists(signedRpm)) {
+        if (!Files.exists(PUBLIC_KEY) || !Files.exists(signedRpm)) {
             fail("Input files signedRpm or publicKey does not exist");
         }
 
         // extract the plain file name
-        String publicKeyName = publicKey.getFileName().toString();
-        String rpmFileName = signedRpm.getFileName().toString();
+        Path publicKeyName = PUBLIC_KEY.getFileName();
+        Path rpmFileName = signedRpm.getFileName();
 
-        // prepare the script for validating the signature, this includes importing the key and running a verbose check
-        String script = String.format("rpm --import /%s && rpm --verbose --checksig /%s", publicKeyName, rpmFileName);
-
-        // SElinux labeling
-        String mountSuffix = MOUNT_SUFFIX.orElseGet(() -> {
-            if (CONTAINER.equals("podman")) {
-                return ":z";
-            } else {
-                return "";
-            }
-        });
-
-
-        // create the actual command, which we run inside a container, to not mess up the host systems RPM configuration and
-        // because this gives us a predictable RPM version.
-        String[] command = new String[] {
-            CONTAINER, "run", "-tiq", "--rm",
-            "-v", publicKey + ":/" + publicKeyName + mountSuffix,
-            "-v", signedRpm + ":/" + rpmFileName + mountSuffix,
-            "registry.access.redhat.com/ubi9/ubi-minimal:latest", "bash", "-c", script
-        };
-
-        // dump command for local testing
-        dumpCommand(command);
-
-        // run the command and capture the output
-        String output = run(command);
-
-        // split into lines
-        List<String> lines = Arrays.asList(output.split("\\R"));
-
-        // ensure that we find a valid signature for our key
-        assertTrue(lines.contains("    V4 RSA/SHA256 Signature, key ID 679f5723: OK"));
-
-        System.out.println(output);
-    }
-
-    private static void dumpCommand(String[] command) {
-        for (String c : command) {
-            System.out.format("\"%s\" ", c);
+        try (final GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse("registry.access.redhat.com/ubi9/ubi-minimal:latest"))) {
+            container.setCommand(COMMAND);
+            container.withCopyToContainer(Transferable.of(Files.readAllBytes(PUBLIC_KEY), DEFAULT_FILE_MODE), "/" + publicKeyName);
+            container.withCopyToContainer(Transferable.of(Files.readAllBytes(signedRpm), DEFAULT_FILE_MODE), "/" + rpmFileName);
+            container.start();
+            ExecResult importResult = container.execInContainer("rpm", "--import", "/" + publicKeyName);
+            assertEquals(0, importResult.getExitCode());
+            ExecResult checksigResult = container.execInContainer("rpm", "--verbose", "--checksig", "/" + rpmFileName);
+            assertEquals(0, checksigResult.getExitCode());
+            String stdout = checksigResult.getStdout();
+            List<String> lines = stdout.lines().collect(Collectors.toList());
+            // ensure that we find a valid signature for our key
+            assertTrue(lines.contains("    V4 RSA/SHA256 Signature, key ID 679f5723: OK"));
+            System.out.println(stdout);
         }
-        System.out.println();
     }
-
-    private static String run(String... command) throws IOException, InterruptedException {
-        Process process = new ProcessBuilder(command)
-            .start();
-        String stdout = new String(ByteStreams.toByteArray(process.getInputStream()));
-        process.waitFor();
-        return stdout;
-    }
-
 }


### PR DESCRIPTION
* Removes requirement on rpm binary
  - Fixes issues with capturing rpm process stdout on Windows
* Removes requirement on podman binary
  - Can use any Docker-API compatible container runtime