### PR TITLE
Change header value reading code to use enum constants and lambdas

### DIFF
--- a/rpm/src/main/java/org/eclipse/packager/rpm/header/Type.java
+++ b/rpm/src/main/java/org/eclipse/packager/rpm/header/Type.java
@@ -24,7 +24,7 @@ public enum Type {
     BLOB(7, 1), //
     STRING_ARRAY(8, 1), //
     I18N_STRING(9, 1), //
-    ;
+    UNKNOWN(Integer.MAX_VALUE, 0);
 
     private final int type;
 
@@ -41,5 +41,15 @@ public enum Type {
 
     public int align() {
         return this.align;
+    }
+
+    public static Type fromType(final int type) {
+        for (final Type t : values()) {
+            if (t.type == type) {
+                return t;
+            }
+        }
+
+        return UNKNOWN;
     }
 }


### PR DESCRIPTION
Instead of using magic constants in `HeaderValue`, use the types already defined in `Type`.