### PR TITLE
Remove use of `Object` in headers and store header value as rpm tag v…

### DIFF
--- a/rpm/src/main/java/org/eclipse/packager/rpm/RpmTagValue.java
+++ b/rpm/src/main/java/org/eclipse/packager/rpm/RpmTagValue.java
@@ -13,6 +13,11 @@
 
 package org.eclipse.packager.rpm;
 
+import org.apache.commons.codec.binary.Hex;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 
 public class RpmTagValue {
@@ -118,8 +123,12 @@ public class RpmTagValue {
             return Optional.empty();
         }
 
+        if (this.value instanceof Integer) {
+            return Optional.of((Integer.toUnsignedLong((Integer) this.value)));
+        }
+
         if (this.value instanceof Long) {
-            return Optional.of(((Long) this.value).longValue());
+            return Optional.of((Long) this.value);
         }
 
         if (this.value instanceof Long[]) {
@@ -132,5 +141,33 @@ public class RpmTagValue {
         }
 
         return Optional.empty();
+    }
+
+    @Override
+    public String toString() {
+        if (this.value instanceof byte[]) {
+            return Hex.encodeHexString((byte[]) this.value);
+        }
+
+        if (this.value instanceof ByteBuffer) {
+            ByteBuffer buffer = (ByteBuffer) this.value;
+            byte[] data;
+
+            if (buffer.hasArray()) {
+                data = buffer.array();
+            } else {
+                data = new byte[buffer.remaining()];
+                buffer.get(data);
+            }
+
+            return Hex.encodeHexString(data);
+        }
+
+        if (this.value instanceof Object[]) {
+            final Object[] array = (Object[]) this.value;
+            return array.length == 1 ? Objects.toString(array[0]) : Arrays.toString((Object[]) this.value);
+        }
+
+        return Objects.toString(this.value);
     }
 }

--- a/rpm/src/main/java/org/eclipse/packager/rpm/build/LeadBuilder.java
+++ b/rpm/src/main/java/org/eclipse/packager/rpm/build/LeadBuilder.java
@@ -21,6 +21,7 @@ import org.eclipse.packager.rpm.Architecture;
 import org.eclipse.packager.rpm.OperatingSystem;
 import org.eclipse.packager.rpm.RpmLead;
 import org.eclipse.packager.rpm.RpmTag;
+import org.eclipse.packager.rpm.RpmTagValue;
 import org.eclipse.packager.rpm.RpmVersion;
 import org.eclipse.packager.rpm.Type;
 import org.eclipse.packager.rpm.header.Header;
@@ -73,8 +74,8 @@ public class LeadBuilder {
         Objects.requireNonNull(architectureMapper);
         Objects.requireNonNull(operatingSystemMapper);
 
-        final Object os = header.get(RpmTag.OS);
-        final Object arch = header.get(RpmTag.ARCH);
+        final Object os = ((RpmTagValue) header.get(RpmTag.OS)).getValue();
+        final Object arch = ((RpmTagValue) header.get(RpmTag.ARCH)).getValue();
 
         if (os instanceof String) {
             this.architecture = architectureMapper.apply((String) os).orElse(Architecture.NOARCH).getValue();

--- a/rpm/src/main/java/org/eclipse/packager/rpm/header/Header.java
+++ b/rpm/src/main/java/org/eclipse/packager/rpm/header/Header.java
@@ -55,9 +55,14 @@ public class Header<T extends RpmBaseTag> implements ReadableHeader<T> {
         public I18nString(final String value) {
             this.value = value;
         }
+
+        @Override
+        public String toString() {
+            return this.value;
+        }
     }
 
-    private final Map<Integer, Object> entries = new LinkedHashMap<>();
+    private final Map<Integer, HeaderEntry> entries = new LinkedHashMap<>();
 
     private final Charset charset;
 
@@ -103,61 +108,61 @@ public class Header<T extends RpmBaseTag> implements ReadableHeader<T> {
     public void putByte(final int tag, final byte... value) {
         Objects.requireNonNull(value);
 
-        this.entries.put(tag, value);
+        this.entries.put(tag, makeEntry(tag, value));
     }
 
     public void putByte(final T tag, final byte... value) {
         Objects.requireNonNull(value);
 
-        this.entries.put(tag.getValue(), value);
+        this.entries.put(tag.getValue(), makeEntry(tag.getValue(), value));
     }
 
     public void putShort(final int tag, final short... value) {
         Objects.requireNonNull(value);
 
-        this.entries.put(tag, value);
+        this.entries.put(tag, makeEntry(tag, value));
     }
 
     public void putShort(final T tag, final short... value) {
         Objects.requireNonNull(value);
 
-        this.entries.put(tag.getValue(), value);
+        this.entries.put(tag.getValue(), makeEntry(tag.getValue(), value));
     }
 
     public void putInt(final int tag, final int... value) {
         Objects.requireNonNull(value);
 
-        this.entries.put(tag, value);
+        this.entries.put(tag, makeEntry(tag, value));
     }
 
     public void putInt(final T tag, final int... value) {
         Objects.requireNonNull(value);
 
-        this.entries.put(tag.getValue(), value);
+        this.entries.put(tag.getValue(), makeEntry(tag.getValue(), value));
     }
 
     public void putLong(final int tag, final long... value) {
         Objects.requireNonNull(value);
 
-        this.entries.put(tag, value);
+        this.entries.put(tag, makeEntry(tag, value));
     }
 
     public void putLong(final T tag, final long... value) {
         Objects.requireNonNull(value);
 
-        this.entries.put(tag.getValue(), value);
+        this.entries.put(tag.getValue(), makeEntry(tag.getValue(), value));
     }
 
     public void putString(final int tag, final String value) {
         Objects.requireNonNull(value);
 
-        this.entries.put(tag, value);
+        this.entries.put(tag, makeEntry(tag, value));
     }
 
     public void putString(final T tag, final String value) {
         Objects.requireNonNull(value);
 
-        this.entries.put(tag.getValue(), value);
+        this.entries.put(tag.getValue(), makeEntry(tag.getValue(), value));
     }
 
     public void putStringOptional(final int tag, final String value) {
@@ -165,7 +170,7 @@ public class Header<T extends RpmBaseTag> implements ReadableHeader<T> {
             return;
         }
 
-        this.entries.put(tag, value);
+        this.entries.put(tag, makeEntry(tag, value));
     }
 
     public void putStringOptional(final T tag, final String value) {
@@ -173,55 +178,55 @@ public class Header<T extends RpmBaseTag> implements ReadableHeader<T> {
             return;
         }
 
-        this.entries.put(tag.getValue(), value);
+        this.entries.put(tag.getValue(), makeEntry(tag.getValue(), value));
     }
 
     public void putStringArray(final int tag, final String... value) {
         Objects.requireNonNull(value);
 
-        this.entries.put(tag, value);
+        this.entries.put(tag, makeEntry(tag, value));
     }
 
     public void putStringArray(final T tag, final String... value) {
         Objects.requireNonNull(value);
 
-        this.entries.put(tag.getValue(), value);
+        this.entries.put(tag.getValue(), makeEntry(tag.getValue(), value));
     }
 
     public void putI18nString(final int tag, final String... value) {
         Objects.requireNonNull(value);
 
-        this.entries.put(tag, Arrays.stream(value).map(v -> new I18nString(v)).toArray(I18nString[]::new));
+        this.entries.put(tag, makeEntry(tag, Arrays.stream(value).map(I18nString::new).toArray(I18nString[]::new)));
     }
 
     public void putI18nString(final T tag, final String... value) {
         Objects.requireNonNull(value);
 
-        this.entries.put(tag.getValue(), Arrays.stream(value).map(v -> new I18nString(v)).toArray(I18nString[]::new));
+        this.entries.put(tag.getValue(), makeEntry(tag.getValue(), Arrays.stream(value).map(I18nString::new).toArray(I18nString[]::new)));
     }
 
     public void putBlob(final int tag, final byte[] value) {
         Objects.requireNonNull(value);
 
-        this.entries.put(tag, ByteBuffer.wrap(value));
+        this.entries.put(tag, makeEntry(tag, ByteBuffer.wrap(value)));
     }
 
     public void putBlob(final int tag, final ByteBuffer value) {
         Objects.requireNonNull(value);
 
-        this.entries.put(tag, value);
+        this.entries.put(tag, makeEntry(tag, value));
     }
 
     public void putBlob(final T tag, final byte[] value) {
         Objects.requireNonNull(value);
 
-        this.entries.put(tag.getValue(), ByteBuffer.wrap(value));
+        this.entries.put(tag.getValue(), makeEntry(tag.getValue(), ByteBuffer.wrap(value)));
     }
 
     public void putBlob(final T tag, final ByteBuffer value) {
         Objects.requireNonNull(value);
 
-        this.entries.put(tag.getValue(), value);
+        this.entries.put(tag.getValue(), makeEntry(tag.getValue(), value));
     }
 
     public void putSize(long value, final T intTag, final T longTag) {
@@ -252,11 +257,11 @@ public class Header<T extends RpmBaseTag> implements ReadableHeader<T> {
     }
 
     public Object get(final int tag) {
-        return this.entries.get(tag);
+        return this.entries.get(tag).getValue();
     }
 
     public Object get(final T tag) {
-        return this.entries.get(tag.getValue());
+        return this.entries.get(tag.getValue()).getValue();
     }
 
     @Override
@@ -278,11 +283,11 @@ public class Header<T extends RpmBaseTag> implements ReadableHeader<T> {
         if (charset == null) {
             throw new IllegalArgumentException("'charset' cannot be null");
         }
-        return this.entries.entrySet().stream().map(this::makeEntry).toArray(num -> new HeaderEntry[num]);
+        return this.entries.entrySet().stream().map(entry -> makeEntry(entry, charset)).toArray(HeaderEntry[]::new);
     }
 
-    private HeaderEntry makeEntry(final Map.Entry<Integer, Object> entry) {
-        return makeEntry(entry, charset);
+    private HeaderEntry makeEntry(final Map.Entry<Integer, HeaderEntry> entry) {
+        return makeEntry(entry, this.charset);
     }
 
     /**
@@ -298,18 +303,18 @@ public class Header<T extends RpmBaseTag> implements ReadableHeader<T> {
         return makeEntries(StandardCharsets.UTF_8);
     }
 
-    private static HeaderEntry makeEntry(final Map.Entry<Integer, Object> entry, final Charset charset) {
-        final Object val = entry.getValue();
-        final int tag = entry.getKey();
+    private static HeaderEntry makeEntry(final Map.Entry<Integer, HeaderEntry> entry, final Charset charset) {
+        return entry.getValue();
+    }
 
-        if (val instanceof HeaderEntry) {
-            return (HeaderEntry) val;
-        }
+    private static HeaderEntry makeEntry(int tag, Object val) {
+        return makeEntry(tag, val, StandardCharsets.UTF_8);
+    }
 
+    private static HeaderEntry makeEntry(int tag, Object val, Charset charset) {
         // NULL
-
         if (val == null) {
-            return new HeaderEntry(Type.NULL, tag, 0, null);
+            return new HeaderEntry(Type.NULL, tag, 0, null, val);
         }
 
         // FIXME: CHAR
@@ -318,7 +323,7 @@ public class Header<T extends RpmBaseTag> implements ReadableHeader<T> {
 
         if (val instanceof byte[]) {
             final byte[] value = (byte[]) val;
-            return new HeaderEntry(Type.BYTE, tag, value.length, value);
+            return new HeaderEntry(Type.BYTE, tag, value.length, value, val);
         }
 
         // SHORT
@@ -332,7 +337,7 @@ public class Header<T extends RpmBaseTag> implements ReadableHeader<T> {
                 buffer.putShort(v);
             }
 
-            return new HeaderEntry(Type.SHORT, tag, value.length, data);
+            return new HeaderEntry(Type.SHORT, tag, value.length, data, val);
         }
 
         // INT
@@ -346,7 +351,7 @@ public class Header<T extends RpmBaseTag> implements ReadableHeader<T> {
                 buffer.putInt(v);
             }
 
-            return new HeaderEntry(Type.INT, tag, value.length, data);
+            return new HeaderEntry(Type.INT, tag, value.length, data, val);
         }
 
         // LONG
@@ -360,7 +365,7 @@ public class Header<T extends RpmBaseTag> implements ReadableHeader<T> {
                 buffer.putLong(v);
             }
 
-            return new HeaderEntry(Type.LONG, tag, value.length, data);
+            return new HeaderEntry(Type.LONG, tag, value.length, data, val);
         }
 
         // STRING
@@ -368,7 +373,7 @@ public class Header<T extends RpmBaseTag> implements ReadableHeader<T> {
         if (val instanceof String) {
             final String value = (String) val;
 
-            return new HeaderEntry(Type.STRING, tag, 1, makeStringData(new ByteArrayOutputStream(), value, charset).toByteArray());
+            return new HeaderEntry(Type.STRING, tag, 1, makeStringData(new ByteArrayOutputStream(), value, charset).toByteArray(), val);
         }
 
         // BLOB
@@ -382,7 +387,7 @@ public class Header<T extends RpmBaseTag> implements ReadableHeader<T> {
                 data = new byte[value.remaining()];
                 value.get(data);
             }
-            return new HeaderEntry(Type.BLOB, tag, data.length, data);
+            return new HeaderEntry(Type.BLOB, tag, data.length, data, val);
         }
 
         // STRING_ARRAY
@@ -390,7 +395,7 @@ public class Header<T extends RpmBaseTag> implements ReadableHeader<T> {
         if (val instanceof String[]) {
             final String[] value = (String[]) val;
 
-            return new HeaderEntry(Type.STRING_ARRAY, tag, value.length, makeStringsData(new ByteArrayOutputStream(), value, charset).toByteArray());
+            return new HeaderEntry(Type.STRING_ARRAY, tag, value.length, makeStringsData(new ByteArrayOutputStream(), value, charset).toByteArray(), val);
         }
 
         // I18N_STRING
@@ -398,7 +403,7 @@ public class Header<T extends RpmBaseTag> implements ReadableHeader<T> {
         if (val instanceof I18nString[]) {
             final I18nString[] value = (I18nString[]) val;
 
-            return new HeaderEntry(Type.I18N_STRING, tag, value.length, makeStringsData(new ByteArrayOutputStream(), value, charset).toByteArray());
+            return new HeaderEntry(Type.I18N_STRING, tag, value.length, makeStringsData(new ByteArrayOutputStream(), value, charset).toByteArray(), val);
         }
 
         throw new IllegalArgumentException(String.format("Unable to process value type: %s", val.getClass()));
@@ -493,5 +498,4 @@ public class Header<T extends RpmBaseTag> implements ReadableHeader<T> {
 
         header.putLong(tag, values);
     }
-
 }

--- a/rpm/src/main/java/org/eclipse/packager/rpm/header/HeaderEntry.java
+++ b/rpm/src/main/java/org/eclipse/packager/rpm/header/HeaderEntry.java
@@ -13,6 +13,11 @@
 
 package org.eclipse.packager.rpm.header;
 
+import org.apache.commons.codec.binary.Hex;
+import org.eclipse.packager.rpm.RpmTagValue;
+
+import java.util.Objects;
+
 public class HeaderEntry {
     private final Type type;
 
@@ -22,11 +27,14 @@ public class HeaderEntry {
 
     private final byte[] data;
 
-    public HeaderEntry(final Type type, final int tag, final int count, final byte[] data) {
+    private final RpmTagValue value;
+
+    public HeaderEntry(final Type type, final int tag, final int count, final byte[] data, Object value) {
         this.type = type;
         this.tag = tag;
         this.count = count;
         this.data = data;
+        this.value = new RpmTagValue(value);
     }
 
     public Type getType() {
@@ -43,5 +51,14 @@ public class HeaderEntry {
 
     public byte[] getData() {
         return this.data;
+    }
+
+    public RpmTagValue getValue() {
+        return this.value;
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toString(this.value);
     }
 }

--- a/rpm/src/main/java/org/eclipse/packager/rpm/info/RpmInformations.java
+++ b/rpm/src/main/java/org/eclipse/packager/rpm/info/RpmInformations.java
@@ -26,6 +26,7 @@ import org.apache.commons.compress.archivers.cpio.CpioArchiveEntry;
 import org.apache.commons.compress.archivers.cpio.CpioArchiveInputStream;
 import org.eclipse.packager.rpm.RpmSignatureTag;
 import org.eclipse.packager.rpm.RpmTag;
+import org.eclipse.packager.rpm.RpmTagValue;
 import org.eclipse.packager.rpm.info.RpmInformation.Dependency;
 import org.eclipse.packager.rpm.parse.InputHeader;
 import org.eclipse.packager.rpm.parse.RpmInputStream;
@@ -59,6 +60,7 @@ public final class RpmInformations {
 
         result.setInstalledSize(asLong(header.getTag(RpmTag.SIZE)));
         result.setArchiveSize(asLong(header.getTag(RpmTag.ARCHIVE_SIZE)));
+
         if (result.getArchiveSize() == null) {
             result.setArchiveSize(asLong(signature.getTag(RpmSignatureTag.PAYLOAD_SIZE)));
         }
@@ -192,18 +194,7 @@ public final class RpmInformations {
             return null;
         }
 
-        if (value instanceof String) {
-            return (String) value;
-        }
-        if (value instanceof String[]) {
-            final String[] values = (String[]) value;
-            if (values.length > 0) {
-                return values[0];
-            }
-            return null;
-        }
-
-        return value.toString();
+        return new RpmTagValue(value).asString().orElse(null);
     }
 
     public static Long asLong(final Object value) {
@@ -211,15 +202,6 @@ public final class RpmInformations {
             return null;
         }
 
-        if (value instanceof Number) {
-            return ((Number) value).longValue();
-        }
-
-        try {
-            return Long.parseLong(value.toString());
-        } catch (final NumberFormatException e) {
-            return null;
-        }
+        return new RpmTagValue(value).asLong().orElse(null);
     }
-
 }

--- a/rpm/src/main/java/org/eclipse/packager/rpm/signature/RpmFileSignatureProcessor.java
+++ b/rpm/src/main/java/org/eclipse/packager/rpm/signature/RpmFileSignatureProcessor.java
@@ -68,13 +68,13 @@ public class RpmFileSignatureProcessor {
         throws IOException, PGPException {
 
         final long leadLength = 96;
-        long signatureHeaderStart = 0L;
-        long signatureHeaderLength = 0L;
-        long payloadHeaderStart = 0L;
-        long payloadHeaderLength = 0L;
-        long payloadStart = 0L;
-        long archiveSize = 0L;
-        long payloadSize = 0L;
+        long signatureHeaderStart;
+        long signatureHeaderLength;
+        long payloadHeaderStart;
+        long payloadHeaderLength;
+        long payloadStart;
+        long archiveSize;
+        long payloadSize;
         byte[] signatureHeader;
 
         if (!Files.exists(rpm)) {

--- a/rpm/src/test/java/org/eclipse/packager/rpm/StableDependencyOrderTest.java
+++ b/rpm/src/test/java/org/eclipse/packager/rpm/StableDependencyOrderTest.java
@@ -51,12 +51,12 @@ class StableDependencyOrderTest {
         Collections.reverse(requirementsReverse);
         Dependencies.putRequirements(header2, requirementsReverse);
 
-        assertThat(header2.get(REQUIRE_NAME)).isEqualTo(header1.get(REQUIRE_NAME));
-        assertThat(header2.get(REQUIRE_VERSION)).isEqualTo(header1.get(REQUIRE_VERSION));
+        assertThat(((RpmTagValue) header2.get(REQUIRE_NAME)).getValue()).isEqualTo(((RpmTagValue) header1.get(REQUIRE_NAME)).getValue());
+        assertThat(((RpmTagValue) header2.get(REQUIRE_VERSION)).getValue()).isEqualTo(((RpmTagValue) header1.get(REQUIRE_VERSION)).getValue());
         assertThat(getRequireFlags(header2)).isEqualTo(getRequireFlags(header1));
     }
 
     private static List<Set<RpmDependencyFlags>> getRequireFlags(Header<RpmTag> header) {
-        return Arrays.stream((int[]) header.get(REQUIRE_FLAGS)).mapToObj(RpmDependencyFlags::parse).collect(Collectors.toUnmodifiableList());
+        return Arrays.stream((int[]) ((RpmTagValue) header.get(REQUIRE_FLAGS)).getValue()).mapToObj(RpmDependencyFlags::parse).collect(Collectors.toUnmodifiableList());
     }
 }


### PR DESCRIPTION
…alue

An attempt at removing some duplicate code between `RpmTagValue` and `RpmInformations`.

Improve type safety by always storing a `HeaderEntry` in the header map instead of raw `Object`. This required a small API change to call `getValue()` now to get the actual value, and the stored value was changed to `RpmTagValue` instead of `Object` inside the `HeaderEntry` itself.

I think another possible improvement that is not in this pull request as it requires more code changes is to avoid returning `Object` from the `get()` API, and instead return an `RpmTagValue` and have the caller have to provide `asLong()` or `asString()` instead of casting, which may provide better type safety.
