### PR TITLE
Fix scriptlet required dependeny flags

### DIFF
--- a/rpm/src/main/java/org/eclipse/packager/rpm/build/RpmBuilder.java
+++ b/rpm/src/main/java/org/eclipse/packager/rpm/build/RpmBuilder.java
@@ -1260,7 +1260,7 @@ public class RpmBuilder implements AutoCloseable {
     private void addInterpreterRequirement(final String interpreter, RpmDependencyFlags scriptPhaseFlag) {
         if (isEmbeddedLuaInterpreter(interpreter)) {
             addRequirement(EMBEDDED_LUA_INTERPRETER_REQUIREMENT_NAME, EMBEDDED_LUA_INTERPRETER_REQUIREMENT_VERSION,
-                scriptPhaseFlag, RpmDependencyFlags.INTERPRETER, RpmDependencyFlags.LESS, RpmDependencyFlags.EQUAL, RpmDependencyFlags.RPMLIB);
+                RpmDependencyFlags.LESS, RpmDependencyFlags.EQUAL, RpmDependencyFlags.RPMLIB);
         } else {
             addRequirement(interpreter, null, scriptPhaseFlag, RpmDependencyFlags.INTERPRETER);
         }

--- a/rpm/src/main/java/org/eclipse/packager/rpm/build/RpmBuilder.java
+++ b/rpm/src/main/java/org/eclipse/packager/rpm/build/RpmBuilder.java
@@ -1260,11 +1260,8 @@ public class RpmBuilder implements AutoCloseable {
     private void addInterpreterRequirement(final String interpreter, RpmDependencyFlags scriptPhaseFlag) {
         if (isEmbeddedLuaInterpreter(interpreter)) {
             addRequirement(EMBEDDED_LUA_INTERPRETER_REQUIREMENT_NAME, EMBEDDED_LUA_INTERPRETER_REQUIREMENT_VERSION,
-                RpmDependencyFlags.INTERPRETER, RpmDependencyFlags.LESS, RpmDependencyFlags.EQUAL, RpmDependencyFlags.RPMLIB);
-            addRequirement(EMBEDDED_LUA_INTERPRETER_REQUIREMENT_NAME, EMBEDDED_LUA_INTERPRETER_REQUIREMENT_VERSION,
                 scriptPhaseFlag, RpmDependencyFlags.INTERPRETER, RpmDependencyFlags.LESS, RpmDependencyFlags.EQUAL, RpmDependencyFlags.RPMLIB);
         } else {
-            addRequirement(interpreter, null, RpmDependencyFlags.INTERPRETER);
             addRequirement(interpreter, null, scriptPhaseFlag, RpmDependencyFlags.INTERPRETER);
         }
     }

--- a/rpm/src/test/java/org/eclipse/packager/rpm/ScriptletWriterTest.java
+++ b/rpm/src/test/java/org/eclipse/packager/rpm/ScriptletWriterTest.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.eclipse.packager.rpm.app.Dumper;
 import org.eclipse.packager.rpm.build.RpmBuilder;
 import org.eclipse.packager.rpm.deps.Dependency;
 import org.eclipse.packager.rpm.deps.RpmDependencyFlags;
@@ -70,12 +71,9 @@ public class ScriptletWriterTest {
         Path outFile;
 
         List<Dependency> expectedRequiredDependencies = List.of(
-            new Dependency("rpmlib(BuiltinLuaScripts)", "4.2.2-1", RpmDependencyFlags.LESS, RpmDependencyFlags.EQUAL, RpmDependencyFlags.RPMLIB, RpmDependencyFlags.INTERPRETER),
             new Dependency("rpmlib(BuiltinLuaScripts)", "4.2.2-1", RpmDependencyFlags.LESS, RpmDependencyFlags.EQUAL, RpmDependencyFlags.RPMLIB, RpmDependencyFlags.INTERPRETER, RpmDependencyFlags.SCRIPT_PRE),
             new Dependency("rpmlib(BuiltinLuaScripts)", "4.2.2-1", RpmDependencyFlags.LESS, RpmDependencyFlags.EQUAL, RpmDependencyFlags.RPMLIB, RpmDependencyFlags.INTERPRETER, RpmDependencyFlags.PRETRANS),
-            new Dependency(customInterpreter, "", RpmDependencyFlags.INTERPRETER),
             new Dependency(customInterpreter, "", RpmDependencyFlags.INTERPRETER, RpmDependencyFlags.SCRIPT_POST),
-            new Dependency(shellInterpreter, "", RpmDependencyFlags.INTERPRETER),
             new Dependency(shellInterpreter, "", RpmDependencyFlags.INTERPRETER, RpmDependencyFlags.SCRIPT_POSTUN),
             new Dependency(shellInterpreter, "", RpmDependencyFlags.INTERPRETER, RpmDependencyFlags.POSTTRANS),
             new Dependency("rpmlib(CompressedFileNames)", "3.0.4-1", RpmDependencyFlags.LESS, RpmDependencyFlags.EQUAL, RpmDependencyFlags.RPMLIB),
@@ -137,7 +135,6 @@ public class ScriptletWriterTest {
 
     public static List<Dependency> simpleLuaDependencyFor(RpmDependencyFlags scriptletPhase) {
         return List.of(
-            new Dependency("rpmlib(BuiltinLuaScripts)", "4.2.2-1", RpmDependencyFlags.LESS, RpmDependencyFlags.EQUAL, RpmDependencyFlags.RPMLIB, RpmDependencyFlags.INTERPRETER),
             new Dependency("rpmlib(BuiltinLuaScripts)", "4.2.2-1", RpmDependencyFlags.LESS, RpmDependencyFlags.EQUAL, RpmDependencyFlags.RPMLIB, RpmDependencyFlags.INTERPRETER, scriptletPhase),
             new Dependency("rpmlib(CompressedFileNames)", "3.0.4-1", RpmDependencyFlags.LESS, RpmDependencyFlags.EQUAL, RpmDependencyFlags.RPMLIB),
             new Dependency("rpmlib(PayloadFilesHavePrefix)", "4.0-1", RpmDependencyFlags.LESS, RpmDependencyFlags.EQUAL, RpmDependencyFlags.RPMLIB));
@@ -145,7 +142,6 @@ public class ScriptletWriterTest {
 
     public static List<Dependency> simpleInterpreterDependencyFor(String interpreter, RpmDependencyFlags scriptletPhase) {
         return List.of(
-            new Dependency(interpreter, "", RpmDependencyFlags.INTERPRETER),
             new Dependency(interpreter, "", RpmDependencyFlags.INTERPRETER, scriptletPhase),
             new Dependency("rpmlib(CompressedFileNames)", "3.0.4-1", RpmDependencyFlags.LESS, RpmDependencyFlags.EQUAL, RpmDependencyFlags.RPMLIB),
             new Dependency("rpmlib(PayloadFilesHavePrefix)", "4.0-1", RpmDependencyFlags.LESS, RpmDependencyFlags.EQUAL, RpmDependencyFlags.RPMLIB));

--- a/rpm/src/test/java/org/eclipse/packager/rpm/ScriptletWriterTest.java
+++ b/rpm/src/test/java/org/eclipse/packager/rpm/ScriptletWriterTest.java
@@ -71,8 +71,7 @@ public class ScriptletWriterTest {
         Path outFile;
 
         List<Dependency> expectedRequiredDependencies = List.of(
-            new Dependency("rpmlib(BuiltinLuaScripts)", "4.2.2-1", RpmDependencyFlags.LESS, RpmDependencyFlags.EQUAL, RpmDependencyFlags.RPMLIB, RpmDependencyFlags.INTERPRETER, RpmDependencyFlags.SCRIPT_PRE),
-            new Dependency("rpmlib(BuiltinLuaScripts)", "4.2.2-1", RpmDependencyFlags.LESS, RpmDependencyFlags.EQUAL, RpmDependencyFlags.RPMLIB, RpmDependencyFlags.INTERPRETER, RpmDependencyFlags.PRETRANS),
+            new Dependency("rpmlib(BuiltinLuaScripts)", "4.2.2-1", RpmDependencyFlags.LESS, RpmDependencyFlags.EQUAL, RpmDependencyFlags.RPMLIB),
             new Dependency(customInterpreter, "", RpmDependencyFlags.INTERPRETER, RpmDependencyFlags.SCRIPT_POST),
             new Dependency(shellInterpreter, "", RpmDependencyFlags.INTERPRETER, RpmDependencyFlags.SCRIPT_POSTUN),
             new Dependency(shellInterpreter, "", RpmDependencyFlags.INTERPRETER, RpmDependencyFlags.POSTTRANS),
@@ -115,13 +114,13 @@ public class ScriptletWriterTest {
         final String shell = "/bin/sh";
         return Stream.of(
             // lua interpreter
-            Arguments.of((ScriptletConsumer) RpmBuilder::setPreInstallationScript, RpmTag.PREINSTALL_SCRIPT, RpmTag.PREINSTALL_SCRIPT_PROG, lua, "my preinstall script", simpleLuaDependencyFor(RpmDependencyFlags.SCRIPT_PRE)),
-            Arguments.of((ScriptletConsumer) RpmBuilder::setPostInstallationScript, RpmTag.POSTINSTALL_SCRIPT, RpmTag.POSTINSTALL_SCRIPT_PROG, lua, "my postinstall script", simpleLuaDependencyFor(RpmDependencyFlags.SCRIPT_POST)),
-            Arguments.of((ScriptletConsumer) RpmBuilder::setPreRemoveScript, RpmTag.PREREMOVE_SCRIPT, RpmTag.PREREMOVE_SCRIPT_PROG, lua, "my preremove script", simpleLuaDependencyFor(RpmDependencyFlags.SCRIPT_PREUN)),
-            Arguments.of((ScriptletConsumer) RpmBuilder::setPostRemoveScript, RpmTag.POSTREMOVE_SCRIPT, RpmTag.POSTREMOVE_SCRIPT_PROG, lua, "my postremove script", simpleLuaDependencyFor(RpmDependencyFlags.SCRIPT_POSTUN)),
-            Arguments.of((ScriptletConsumer) RpmBuilder::setPreTransactionScript, RpmTag.PRETRANSACTION_SCRIPT, RpmTag.PRETRANSACTION_SCRIPT_PROG, lua, "my pretransaction script", simpleLuaDependencyFor(RpmDependencyFlags.PRETRANS)),
-            Arguments.of((ScriptletConsumer) RpmBuilder::setPostTransactionScript, RpmTag.POSTTRANSACTION_SCRIPT, RpmTag.POSTTRANSACTION_SCRIPT_PROG, lua, "my posttransaction script", simpleLuaDependencyFor(RpmDependencyFlags.POSTTRANS)),
-            Arguments.of((ScriptletConsumer) RpmBuilder::setVerifyScript, RpmTag.VERIFY_SCRIPT, RpmTag.VERIFY_SCRIPT_PROG, lua, "my verify script", simpleLuaDependencyFor(RpmDependencyFlags.SCRIPT_VERIFY)),
+            Arguments.of((ScriptletConsumer) RpmBuilder::setPreInstallationScript, RpmTag.PREINSTALL_SCRIPT, RpmTag.PREINSTALL_SCRIPT_PROG, lua, "my preinstall script", simpleLuaDependency()),
+            Arguments.of((ScriptletConsumer) RpmBuilder::setPostInstallationScript, RpmTag.POSTINSTALL_SCRIPT, RpmTag.POSTINSTALL_SCRIPT_PROG, lua, "my postinstall script", simpleLuaDependency()),
+            Arguments.of((ScriptletConsumer) RpmBuilder::setPreRemoveScript, RpmTag.PREREMOVE_SCRIPT, RpmTag.PREREMOVE_SCRIPT_PROG, lua, "my preremove script", simpleLuaDependency()),
+            Arguments.of((ScriptletConsumer) RpmBuilder::setPostRemoveScript, RpmTag.POSTREMOVE_SCRIPT, RpmTag.POSTREMOVE_SCRIPT_PROG, lua, "my postremove script", simpleLuaDependency()),
+            Arguments.of((ScriptletConsumer) RpmBuilder::setPreTransactionScript, RpmTag.PRETRANSACTION_SCRIPT, RpmTag.PRETRANSACTION_SCRIPT_PROG, lua, "my pretransaction script", simpleLuaDependency()),
+            Arguments.of((ScriptletConsumer) RpmBuilder::setPostTransactionScript, RpmTag.POSTTRANSACTION_SCRIPT, RpmTag.POSTTRANSACTION_SCRIPT_PROG, lua, "my posttransaction script", simpleLuaDependency()),
+            Arguments.of((ScriptletConsumer) RpmBuilder::setVerifyScript, RpmTag.VERIFY_SCRIPT, RpmTag.VERIFY_SCRIPT_PROG, lua, "my verify script", simpleLuaDependency()),
             // shell interpreter
             Arguments.of((ScriptletConsumer) RpmBuilder::setPreInstallationScript, RpmTag.PREINSTALL_SCRIPT, RpmTag.PREINSTALL_SCRIPT_PROG, shell, "my preinstall script", simpleInterpreterDependencyFor(shell, RpmDependencyFlags.SCRIPT_PRE)),
             Arguments.of((ScriptletConsumer) RpmBuilder::setPostInstallationScript, RpmTag.POSTINSTALL_SCRIPT, RpmTag.POSTINSTALL_SCRIPT_PROG, shell, "my postinstall script", simpleInterpreterDependencyFor(shell, RpmDependencyFlags.SCRIPT_POST)),
@@ -133,9 +132,9 @@ public class ScriptletWriterTest {
         );
     }
 
-    public static List<Dependency> simpleLuaDependencyFor(RpmDependencyFlags scriptletPhase) {
+    public static List<Dependency> simpleLuaDependency() {
         return List.of(
-            new Dependency("rpmlib(BuiltinLuaScripts)", "4.2.2-1", RpmDependencyFlags.LESS, RpmDependencyFlags.EQUAL, RpmDependencyFlags.RPMLIB, RpmDependencyFlags.INTERPRETER, scriptletPhase),
+            new Dependency("rpmlib(BuiltinLuaScripts)", "4.2.2-1", RpmDependencyFlags.LESS, RpmDependencyFlags.EQUAL, RpmDependencyFlags.RPMLIB),
             new Dependency("rpmlib(CompressedFileNames)", "3.0.4-1", RpmDependencyFlags.LESS, RpmDependencyFlags.EQUAL, RpmDependencyFlags.RPMLIB),
             new Dependency("rpmlib(PayloadFilesHavePrefix)", "4.0-1", RpmDependencyFlags.LESS, RpmDependencyFlags.EQUAL, RpmDependencyFlags.RPMLIB));
     }


### PR DESCRIPTION
PR as mentioned in https://github.com/eclipse/packager/pull/66#issuecomment-2340030989 and https://github.com/eclipse/packager/pull/66#issuecomment-2340299994

- Remove 2nd required dependency entry added by scriptlet setter
- Add required dependency rpmlib(BuiltinLuaScripts) for lua scriptles only with flags LESS, EQUAL, RPMLIB