### PR TITLE
Enable publishing snapshots using central portal

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,4 +25,32 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven
-      run: mvn -B verify --file pom.xml
+      run: mvn -B -V verify --file pom.xml
+
+  snapshot:
+    if: |
+      github.repository == 'eclipse/packager' &&
+      github.event_name == 'push' && github.ref == 'refs/heads/master' &&
+      !contains(github.event.head_commit.message, '[maven-release-plugin] prepare release')
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 11
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: 11
+    # https://github.com/marketplace/actions/maven-setings-action
+    - name: Maven Settings
+      uses: s4u/maven-settings-action@v3.1.0
+      with:
+        sonatypeSnapshots: true
+        githubServer: false
+        servers: |
+            [{
+                "id": "central",
+                "username": "${{ secrets.SONATYPE_USERNAME }}",
+                "password": "${{ secrets.SONATYPE_PASSWORD }}"
+            }]
+    - name: Deploy Snapshot
+      run: mvn -B -V deploy

--- a/pom.xml
+++ b/pom.xml
@@ -50,17 +50,6 @@
         <system>GitHub</system>
     </issueManagement>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
-
     <modules>
         <module>core</module>
         <module>deb</module>
@@ -107,7 +96,6 @@
 
     <dependencyManagement>
         <dependencies>
-
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcprov-jdk18on</artifactId>
@@ -215,6 +203,7 @@
 
         </dependencies>
     </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.assertj</groupId>
@@ -351,7 +340,15 @@
         </pluginManagement>
 
         <plugins>
-
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.7.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <publishingServerId>central</publishingServerId>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>


### PR DESCRIPTION
This is for https://central.sonatype.org/news/20250326_ossrh_sunset and also enables publishing snapshots following https://central.sonatype.org/publish/publish-portal-maven/

This will require the repository to be migrated to the new central portal system.

Secondly it will require two secrets added to the repository ( https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository ) from the tokens generated in https://central.sonatype.org/publish/generate-portal-token named for `SONATYPE_USERNAME` and `SONATYPE_PASSWORD` to enable successful snapshot publishing.